### PR TITLE
fix(stats): scoped Azure DevOps repo count to date range

### DIFF
--- a/main.go
+++ b/main.go
@@ -980,8 +980,6 @@ func FetchAzureDevOpsStats(organization, accessToken string, from, to time.Time,
 			continue
 		}
 
-		stats.TotalRepos += len(reposResult.Value)
-
 		// Count commits with dates
 		for _, repo := range reposResult.Value {
 			repoHadCommits := false
@@ -1103,6 +1101,8 @@ func FetchAzureDevOpsStats(organization, accessToken string, from, to time.Time,
 			skip += 100
 		}
 	}
+
+	stats.TotalRepos = len(activeRepos)
 
 	// Fetch languages only from repos the user committed to.
 	// Skip language fetching in daily mode as it is the expensive part.


### PR DESCRIPTION
## Summary
- Replaced unconditional org-wide repo counting (`len(reposResult.Value)`) with `len(activeRepos)`, which only includes repos where the user had commits in the requested `from`/`to` window
- Fixes inflated Azure DevOps repo counts appearing in years before the user started using the platform (e.g., 2022 and earlier)

## Test plan
- [ ] Run `make test` to verify existing tests pass
- [ ] Recalculate a year with no Azure DevOps activity and confirm `TotalRepos` is 0
- [ ] Recalculate a year with Azure DevOps activity and confirm `TotalRepos` reflects only repos with commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)