### PR TITLE
chore(ai-docs): refresh AI assistant guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,7 @@
 
 Go application that fetches user statistics from GitHub, GitLab, and Azure DevOps APIs and generates SVG visualizations for a GitHub profile README. Persists daily snapshots to `stats_history.json` for historical accumulation, then generates per-year SVG widgets. Runs daily via GitHub Actions, outputting to the `stats` branch.
 
-Single-file Go app (`main.go` only). Requires Go 1.26+. Direct dependencies: `golang.org/x/text` (number formatting) and `stretchr/testify` (testing).
+Single-file Go app (`main.go` only). Requires Go 1.26+. Direct dependencies: `sirupsen/logrus` (logging) and `stretchr/testify` (testing).
 
 ## Build and Test Commands
 
@@ -61,7 +61,7 @@ Single-package monolith (`package main` in `main.go`). Key components:
 - Uses `stretchr/testify` for assertions (`assert`, `require`)
 - Tests are parallel (`t.Parallel()` + `t.Run()`)
 - BDD structure with `// given`, `// when`, `// then` comments
-- Two test files: `helpers_test.go` and `svg_generators_test.go`
+- Three test files: `fetchers_test.go` (platform fetcher HTTP mocking), `helpers_test.go` (helpers and utilities), and `svg_generators_test.go` (SVG renderers)
 
 ## Generated Output Files
 
@@ -88,6 +88,7 @@ All workflows check out `main`, restore `stats_history.json` from the `stats` br
 
 ```
 ├── main.go                           # Single-file application
+├── fetchers_test.go                  # Unit tests for platform fetchers
 ├── helpers_test.go                   # Unit tests for helpers and utilities
 ├── svg_generators_test.go            # Unit tests for SVG renderers
 ├── go.mod / go.sum                   # Go module definition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to correct dependency listing (`sirupsen/logrus` replaced `golang.org/x/text`), document `fetchers_test.go`, and add the README updater to the architecture section
+
 ## [0.2.2] - 2026-04-19
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Go application that fetches user statistics from GitHub, GitLab, and Azure DevOps APIs and generates SVG visualizations for a GitHub profile README. Persists daily snapshots to `stats_history.json` for historical accumulation, then generates per-year SVG widgets. Runs daily via GitHub Actions, outputting to the `stats` branch.
 
-Single-file Go app (`main.go` only -- no `cmd/`, `internal/`, or multi-package structure). Requires Go 1.26+. Direct dependencies: `golang.org/x/text` (number formatting) and `stretchr/testify` (testing).
+Single-file Go app (`main.go` only -- no `cmd/`, `internal/`, or multi-package structure). Requires Go 1.26+. Direct dependencies: `sirupsen/logrus` (logging) and `stretchr/testify` (testing).
 
 ## Build and Test Commands
 
@@ -62,7 +62,8 @@ Single-package monolith (`package main` in `main.go`). Key components:
   - `renderLanguagesBarChart(map[string]map[PlatformName]int64)` -- stacked bar chart
   - `renderContributionHeatmap(contribs, startDate, endDate)` -- heatmap with full year range
 - **Run modes**: `daily` (today only, reuses languages), `bootstrap` (full current year), `recalculate` (full target year, replaces all snapshots for that year via `removeSnapshotsForYear`, regenerates SVGs for all years)
-- **`main()` flow**: Load history -> fetch platforms (parallel) -> save snapshot -> accumulate by year -> generate per-year SVGs (full year range) -> copy current year to `_final.svg` -> generate tokens graph
+- **README updater** (`updateReadmeYearSections`): After generating per-year SVGs, auto-inserts new year `<details>` blocks into `README.md` in descending order. Skips the current year (handled by `_final.svg`).
+- **`main()` flow**: Load history -> fetch platforms (parallel) -> save snapshot -> accumulate by year -> generate per-year SVGs (full year range) -> copy current year to `_final.svg` -> update README year sections -> generate tokens graph
 
 Platform colors: GitHub `#238636`, GitLab `#e24329`, Azure DevOps `#0078d4`. Unified card chrome: `rx="4.5"`, `fill="#151515"`, `stroke="#e4e2e2"`, `stroke-opacity="0.2"`.
 
@@ -73,7 +74,7 @@ Platform colors: GitHub `#238636`, GitLab `#e24329`, Azure DevOps `#0078d4`. Uni
 - Tests are parallel (`t.Parallel()` + `t.Run()`)
 - BDD structure with `// given`, `// when`, `// then` comments
 - SVG output validated as well-formed XML via `assertValidSVGXML` helper
-- Two test files: `helpers_test.go` (formatNumber, aggregation, history persistence, year accumulation) and `svg_generators_test.go` (all four SVG renderers, year tabs)
+- Three test files: `fetchers_test.go` (platform fetcher HTTP mocking), `helpers_test.go` (formatNumber, aggregation, history persistence, year accumulation), and `svg_generators_test.go` (all four SVG renderers, year tabs)
 
 ## Generated Output Files
 


### PR DESCRIPTION
Automated weekly refresh by `ai-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed `CLAUDE.md` and `.github/copilot-instructions.md` against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.