### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -99,11 +99,12 @@ All workflows check out `main`, restore `stats_history.json` from the `stats` br
 ├── CONTRIBUTING.md                   # Contribution guidelines
 ├── stats_history.json                # Daily snapshots (on stats branch)
 ├── claude_tokens.json                # Token usage data (on stats branch)
-├── .github/
-│   ├── copilot-instructions.md       # This file
-│   └── workflows/
-│       ├── update-stats.yml          # Daily stats workflow
-│       ├── bootstrap-stats.yml       # Bootstrap workflow
-│       └── recalculate-stats.yml     # Recalculate workflow
-└── .assets/                          # Custom SVG icons
+└── .github/
+    ├── copilot-instructions.md       # This file
+    └── workflows/
+        ├── update-stats.yml          # Daily stats workflow
+        ├── bootstrap-stats.yml       # Bootstrap workflow
+        ├── recalculate-stats.yml     # Recalculate workflow
+        ├── claude-code-review.yaml   # Automated PR review via Claude Code
+        └── claude.yaml               # Interactive Claude Code on issues/comments
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Changed
 
 - refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to correct dependency listing (`sirupsen/logrus` replaced `golang.org/x/text`), document `fetchers_test.go`, and add the README updater to the architecture section
+- refreshed `CLAUDE.md` to add `LOG_LEVEL` env var, document the two Claude CI workflows, and fix stale documentation section; updated `.github/copilot-instructions.md` to fix repository structure tree
 
 ## [0.2.2] - 2026-04-19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ Path configuration (defaults work for local development):
 |----------------------|----------------------|------------------------------------------------------------|
 | `RUN_MODE`           | `daily`              | Operating mode: `daily`, `bootstrap`, or `recalculate`     |
 | `TARGET_YEAR`        | (none)               | Year to recalculate (required when `RUN_MODE=recalculate`) |
+| `LOG_LEVEL`          | `info`               | Log verbosity: `info` or `debug`                           |
 | `STATS_HISTORY_PATH` | `stats_history.json` | Path to read/write historical snapshots                    |
 | `SVG_OUTPUT_DIR`     | `.`                  | Directory for generated SVG files                          |
 | `README_PATH`        | `README.md`          | Path to README for auto-inserting new year sections        |
@@ -90,13 +91,17 @@ Per-year SVGs (e.g., `combined_stats_2026.svg`) plus `_final.svg` aliases pointi
 
 ## CI/CD
 
-Three workflows in `.github/workflows/`:
+Five workflows in `.github/workflows/`. Three handle stats generation:
 - **`update-stats.yml`**: Runs daily at midnight UTC via `schedule` and can be triggered manually via `workflow_dispatch`. `RUN_MODE=daily`.
 - **`bootstrap-stats.yml`**: Manual dispatch only. `RUN_MODE=bootstrap`. Full current-year fetch with languages.
 - **`recalculate-stats.yml`**: Manual dispatch only with `year` input. `RUN_MODE=recalculate`. Re-fetches all data for the given year, replaces that year's snapshots, and regenerates SVGs for all years.
 
-All workflows check out `main`, restore `stats_history.json` from the `stats` branch, run the generator, and force-push an orphan commit to `stats`.
+All stats workflows check out `main`, restore `stats_history.json` from the `stats` branch, run the generator, and force-push an orphan commit to `stats`.
+
+Two handle Claude Code CI (both delegate to reusable workflows in `rios0rios0/.github`):
+- **`claude-code-review.yaml`**: Runs on pull request events for automated code review.
+- **`claude.yaml`**: Runs on issue/comment/review events for interactive Claude Code assistance.
 
 ## Stale Documentation
 
-`.github/copilot-instructions.md` and `CONTRIBUTING.md` are outdated -- they reference the old template-based SVG approach, claim no tests exist, and list old workflow files. Use this CLAUDE.md as the source of truth.
+`CONTRIBUTING.md` is outdated -- it references old SVG filenames and omits the `-tags=unit` build tag for tests. Use this CLAUDE.md as the source of truth.


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.