### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,6 +42,7 @@ Path configuration (defaults work for local development):
 | `RUN_MODE`           | `daily`              | Operating mode: `daily`, `bootstrap`, or `recalculate`     |
 | `TARGET_YEAR`        | (none)               | Year to recalculate (required when `RUN_MODE=recalculate`) |
 | `STATS_HISTORY_PATH` | `stats_history.json` | Path to read/write historical snapshots                    |
+| `LOG_LEVEL`          | `info`               | Log verbosity: `info` or `debug`                           |
 | `SVG_OUTPUT_DIR`     | `.`                  | Directory for generated SVG files                          |
 | `README_PATH`        | `README.md`          | Path to README for auto-inserting new year sections        |
 
@@ -77,12 +78,19 @@ Per-year SVGs plus `_final.svg` aliases pointing to the current year:
 
 ## CI/CD
 
-Three workflows in `.github/workflows/`:
+Six workflows in `.github/workflows/`. Three handle stats generation:
 - **`update-stats.yml`**: Runs daily at midnight UTC. `RUN_MODE=daily`.
 - **`bootstrap-stats.yml`**: Manual dispatch only. `RUN_MODE=bootstrap`.
 - **`recalculate-stats.yml`**: Manual dispatch with `year` input. `RUN_MODE=recalculate`.
 
-All workflows check out `main`, restore `stats_history.json` from the `stats` branch, run the generator, and force-push an orphan commit to `stats`.
+All stats workflows check out `main`, restore `stats_history.json` from the `stats` branch, run the generator, and force-push an orphan commit to `stats`.
+
+Two handle Claude Code CI (delegate to reusable workflows in `rios0rios0/.github`):
+- **`claude-code-review.yaml`**: Runs on pull request events for automated code review.
+- **`claude.yaml`**: Runs on issue/comment/review events for interactive Claude Code assistance.
+
+One handles releases (delegates to a reusable workflow in `rios0rios0/pipelines`):
+- **`release.yaml`**: Triggers on push to `main`.
 
 ## Repository Structure
 
@@ -106,5 +114,6 @@ All workflows check out `main`, restore `stats_history.json` from the `stats` br
         ├── bootstrap-stats.yml       # Bootstrap workflow
         ├── recalculate-stats.yml     # Recalculate workflow
         ├── claude-code-review.yaml   # Automated PR review via Claude Code
-        └── claude.yaml               # Interactive Claude Code on issues/comments
+        ├── claude.yaml               # Interactive Claude Code on issues/comments
+        └── release.yaml              # Release workflow on push to main
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Changed
 
 - changed the Go module dependencies to their latest versions
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to document the `release.yaml` workflow, correct the workflow count, and add the missing `LOG_LEVEL` env var to copilot instructions
 
 ## [0.2.4] - 2026-05-08
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ Per-year SVGs (e.g., `combined_stats_2026.svg`) plus `_final.svg` aliases pointi
 
 ## CI/CD
 
-Five workflows in `.github/workflows/`. Three handle stats generation:
+Six workflows in `.github/workflows/`. Three handle stats generation:
 - **`update-stats.yml`**: Runs daily at midnight UTC via `schedule` and can be triggered manually via `workflow_dispatch`. `RUN_MODE=daily`.
 - **`bootstrap-stats.yml`**: Manual dispatch only. `RUN_MODE=bootstrap`. Full current-year fetch with languages.
 - **`recalculate-stats.yml`**: Manual dispatch only with `year` input. `RUN_MODE=recalculate`. Re-fetches all data for the given year, replaces that year's snapshots, and regenerates SVGs for all years.
@@ -101,6 +101,9 @@ All stats workflows check out `main`, restore `stats_history.json` from the `sta
 Two handle Claude Code CI (both delegate to reusable workflows in `rios0rios0/.github`):
 - **`claude-code-review.yaml`**: Runs on pull request events for automated code review.
 - **`claude.yaml`**: Runs on issue/comment/review events for interactive Claude Code assistance.
+
+One handles releases (delegates to a reusable workflow in `rios0rios0/pipelines`):
+- **`release.yaml`**: Triggers on push to `main`.
 
 ## Stale Documentation
 


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.