### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` to correct the `svg_generators_test.go` description, which referenced a non-existent "year tabs" test instead of its combo color scale coverage
+
 ## [0.2.6] - 2026-05-22
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Platform colors: GitHub `#238636`, GitLab `#e24329`, Azure DevOps `#0078d4`. Uni
 - Tests are parallel (`t.Parallel()` + `t.Run()`)
 - BDD structure with `// given`, `// when`, `// then` comments
 - SVG output validated as well-formed XML via `assertValidSVGXML` helper
-- Three test files: `fetchers_test.go` (platform fetcher HTTP mocking), `helpers_test.go` (formatNumber, aggregation, history persistence, year accumulation), and `svg_generators_test.go` (all four SVG renderers, year tabs)
+- Three test files: `fetchers_test.go` (platform fetcher HTTP mocking), `helpers_test.go` (formatNumber, aggregation, history persistence, year accumulation), and `svg_generators_test.go` (all four SVG renderers, combo color scales)
 
 ## Generated Output Files
 


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.